### PR TITLE
chore: dependencies

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -10,12 +10,12 @@
   "author": "jambin",
   "license": "MIT",
   "dependencies": {
-    "antd": "~4.10.3",
-    "jquery": "^3.4.1",
-    "react": "~16.12.0",
-    "react-dom": "^16.13.1",
-    "react-router": "~5.1.2",
-    "react-router-dom": "~5.1.2"
+    "antd": "~4.18.2",
+    "jquery": "^3.5.1",
+    "react": "~17.0.1",
+    "react-dom": "^17.0.1",
+    "react-router": "~6.2.1",
+    "react-router-dom": "~6.2.1"
   },
   "devDependencies": {
     "@babel/core": "~7.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-data-mapping",
-  "version": "1.3.9",
+  "version": "1.3.11",
   "description": "数据/字段映射React组件",
   "main": "dist/index.js",
   "pack": "pack/index.js",
@@ -24,13 +24,13 @@
   "author": "无惟",
   "license": "MIT",
   "dependencies": {
-    "butterfly-dag": "~4.1.0"
+    "butterfly-dag": "~4.1.22"
   },
   "peerDependencies": {
-    "react": ">15.6.1",
-    "react-dom": ">15.6.1",
-    "lodash": "^4.17.20",
-    "jquery": ">3.5.1"
+    "react": "~17.0.2",
+    "react-dom": "~17.0.2",
+    "lodash": "^4.17.21",
+    "jquery": "~3.5.1"
   },
   "devDependencies": {
     "@babel/core": "~7.12.0",
@@ -46,8 +46,8 @@
     "@types/react-dom": "^17.0.0",
     "babel-loader": "~8.2.0",
     "babel-plugin-transform-es2015-modules-commonjs": "~6.26.2",
-    "less": "~3.12.2",
-    "postcss": "~8.1.7",
+    "less": "~4.1.2",
+    "postcss": "~8.4.5",
     "rollup": "~2.38.0",
     "rollup-plugin-babel": "~4.4.0",
     "rollup-plugin-commonjs": "~10.1.0",
@@ -57,6 +57,6 @@
     "rollup-plugin-postcss": "~4.0.0",
     "rollup-plugin-typescript2": "~0.29.0",
     "rollup-plugin-url": "~3.0.1",
-    "typescript": "~4.1.3"
+    "typescript": "~4.5.4"
   }
 }


### PR DESCRIPTION
update to latest react version and some other dependencies - so far possible.
Please test it also, with node 16.13.1 & npm 8.1.2 it was working well. 

I'm not sure why you use rollup with babel for build and not webpack only.